### PR TITLE
docs(README.md): specify https protocol for stylesheet urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Include the theme/stylesheet (`https://prismjs.catppuccin.com/<flavor>.css`) in 
 <html>
   <head>
     ...
-    <link href="//prismjs.catppuccin.com/mocha.css" rel="stylesheet" />
+    <link href="https://prismjs.catppuccin.com/mocha.css" rel="stylesheet" />
   </head>
   <body>
     ...


### PR DESCRIPTION
Turns
```html
<link href="//prismjs.catppuccin.com/mocha.css" rel="stylesheet" />
```
into 
```html
<link href="https://prismjs.catppuccin.com/mocha.css" rel="stylesheet" />
```
in the README